### PR TITLE
[sc-163712] Update manifest for default value for global_access_token

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -47,7 +47,8 @@
       "options": { "entrypoint": "#/admin/global-sign-in" },
       "isRequired": true,
       "isBackendOnly": true,
-      "order": 40
+      "order": 40,
+      "default": ""
     },
     "mapping_contact": {
       "title": "Contact Field Mapping",


### PR DESCRIPTION
### Description

The error occurs because Formik expects all values to be strings, and due to the global_access_token field being an `app_embedded` type, rather than a `string` it escapes being converted from a "null" string to a "" string. However it does check the default value in the manifest/settings, which in this case was not used.

Setting the manifest file for the `global_access_token` to an empty string `""`, makes it correctly return an error stating the field is required.

Proof attached to the shortcut story: https://app.shortcut.com/deskpro/story/163712/salesforce-error-in-drawer-when-signing-in-during-set-up