### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -145,9 +145,20 @@
   "proxy": {
     "whitelist": [
       {
-        "url": "https://(.*).salesforce.com/services/.*",
+        "url": "https://__salesforce_instance_url__.salesforce.com/services/.*",
         "methods": ["GET", "POST", "PUT", "DELETE", "PATCH"],
-        "timeout": 30
+        "timeout": 30,
+        "settingsInjection": {
+          "client_key": {
+            "body": ["client_id"]
+          },
+          "client_secret": {
+            "body": ["client_secret"]
+          },
+          "global_access_token": {
+            "body": ["refresh_token"]
+          }
+        }
       }
     ]
   }

--- a/manifest.json
+++ b/manifest.json
@@ -145,7 +145,7 @@
   "proxy": {
     "whitelist": [
       {
-        "url": "https://__salesforce_instance_url__.salesforce.com/services/.*",
+        "url": "__salesforce_instance_url__/services/.*",
         "methods": ["GET", "POST", "PUT", "DELETE", "PATCH"],
         "timeout": 30,
         "settingsInjection": {


### PR DESCRIPTION
This pull request updates the Salesforce proxy configuration in the `manifest.json` file to improve security and flexibility when connecting to Salesforce services. The main change is the replacement of the wildcard URL pattern with a placeholder, and the addition of a mechanism to inject sensitive credentials from settings into request bodies.

Proxy configuration enhancements:

* Changed the Salesforce proxy URL pattern from a wildcard to use the `__salesforce_instance_url__` placeholder for improved explicitness and control.
* Added a `settingsInjection` section to automatically inject `client_key`, `client_secret`, and `global_access_token` from settings into the request body as `client_id`, `client_secret`, and `refresh_token` respectively, enhancing credential management and security.